### PR TITLE
Softened the rating curve when difference is large

### DIFF
--- a/src/eloUpdater.ts
+++ b/src/eloUpdater.ts
@@ -462,9 +462,16 @@ class ELOUpdater {
 	}
 
 	private calculateEloSteal(killerElo: number, victimElo: number, multiplier = 1) {
-		const eloDiff = Math.abs(victimElo - killerElo);
-		const additionalStealConst = killerElo < victimElo ? stealPerEloGainedPoints : -stealPerEloLostPoints;
-		const eloSteal = Math.min(maxEloStealPoints, Math.max((baseEloStealPoints + (eloDiff * additionalStealConst)), minEloStealPoints) * multiplier);
+		let stealBase: number;
+		const diff = victimElo - killerElo;
+		calculate:{
+            if (diff<-1500) {stealBase = 2.5 * Math.exp((diff+1500)/500); break calculate;}
+            if (diff<0) {stealBase = baseEloStealPoints + diff * stealPerEloLostPoints; break calculate;}
+            if (diff<1500) {stealBase = baseEloStealPoints + diff * stealPerEloGainedPoints; break calculate;}
+            else stealBase = 30 - 5 * Math.exp((1500-diff)/500);
+        }
+
+		const eloSteal = Math.min(maxEloStealPoints, stealBase * multiplier);
 		return eloSteal;
 	}
 }


### PR DESCRIPTION
The code should produce exactly the same result when rating difference is below 1500, but outside that it will produce an exponentially decaying gain/loss. Each 500 points of rating difference causes a roughly doubling of K/D ratio to remain stable, more consistent with the trends across the rest of the system. 500 difference requires 2/1 (15 vs 7.5), 1000 requires 4/1 (20 vs 5), 1500 requires 10/1 (25 vs 2.5), and this change will change 2000 from 300/1 (30 vs 0.1) to ~25/1.

Significance of interactions between players of large rating differences is reduced by capping the multiple to 30 (softly). Maybe not required, and not nearly so impactful as the 'linear to zero' issue, but matched exponentials just seems neat to me.

Specific values for multiples have been chosen such that the function is continuous, and the transition to the exponential is differentiable. This second requirement is probably overkill, so the function can be stretched to suit.