### PR TITLE
feat: Add onlinerole command and update role of members when online users updated

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -430,6 +430,7 @@ class API {
 	}[]) {
 		this.app.onlineUsers = users;
 		this.app.lastOnlineUserUpdateAt = Date.now();
+		this.app.updateOnlineRole();
 		return 200;
 	}
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -539,7 +539,7 @@ class Application {
 
 	public async deleteOnlineRole(onlinerole: OnlineRole) {
 		this.log.info(`Deleting onlinerole ${onlinerole.id}`);
-		await this.onlineboardMessages.remove(onlinerole.id);
+		await this.onlineRoles.remove(onlinerole.id);
 	}
 }
 

--- a/src/commands/elo/onlinerole.ts
+++ b/src/commands/elo/onlinerole.ts
@@ -1,0 +1,45 @@
+import Discord from "discord.js";
+import { Command, CommandEvent } from "strike-discord-framework/dist/command.js";
+
+import { Application } from "../../application.js";
+import { Arg } from 'strike-discord-framework/dist/argumentParser.js';
+
+class Onlinerole extends Command {
+	name = "onlinerole";
+	altNames = [];
+	allowDm = false;
+	help = {
+		msg: "Set the role to be given to online users, max 1 per server, must be an admin to run this command",
+		usage: "",
+	};
+
+	async run({ message, framework, app }: CommandEvent<Application>, @Arg() role: Discord.Role) {
+		if (!message.member.permissions.has("ADMINISTRATOR")) {
+			return framework.error(`You must be an admin to run this command`);
+		}
+
+		const existing = await app.onlineRoles.collection.findOne({ guildId: message.guild.id });
+
+		if (existing) {
+			const confirm = await framework.utils.reactConfirm(`There is already a onlinerole in this server, do you want to delete it?`, message);
+			if (confirm) {
+				await app.deleteOnlineRole(existing);
+			}
+		}
+
+		const same = await app.onlineRoles.collection.findOne({ roleId: role.id });
+
+		if (same) {
+			return framework.error(`This role is already set to be given to online users`);
+		}
+
+		const onlinerole = await app.createOnlinerole(role);
+		if (!onlinerole) return framework.error(`An error has occurred while creating the onlinerole`);
+		const msg = await message.channel.send(framework.success(`Onlinerole created!`));
+		await new Promise((resolve) => setTimeout(resolve, 5000));
+		await msg.delete().catch(() => { });
+		await message.delete().catch(() => { });
+	}
+}
+
+export default Onlinerole;

--- a/src/structures.ts
+++ b/src/structures.ts
@@ -48,6 +48,12 @@ export interface OnlineboardMessage {
 	id: string;
 }
 
+export interface OnlineRole {
+	roleId: string;
+	guildId: string;
+	id: string;
+}
+
 export interface User {
 	id: string;
 	pilotNames: string[];


### PR DESCRIPTION
- Command to make a role the onlinerole for the server, can only be one.
- Automatically give onlinerole to users that are online on the server, remove when offline
    - Update only triggered through the api endpoint