### PR TITLE
Added EF-24G to stat command

### DIFF
--- a/src/commands/elo/stats.ts
+++ b/src/commands/elo/stats.ts
@@ -84,7 +84,7 @@ class Stats extends Command {
 		kills = kills.filter(k => shouldKillBeCounted(k));
 		deaths = deaths.filter(k => shouldKillBeCounted(k));
 
-		const aircraftMetrics = [Aircraft.FA26b, Aircraft.F45A, Aircraft.T55];
+		const aircraftMetrics = [Aircraft.FA26b, Aircraft.F45A, Aircraft.T55, Aircraft.EF24G];
 		let killsWith = ``;
 		let killsAgainst = ``;
 		let deathsAgainst = ``;


### PR DESCRIPTION
I added the enum for the EF-24G to the stat command, it looks like the API already suppoerted it so this shouldn't break  anything. 

If there is any specified procedure for contribution please let me know!