### PR TITLE
Allow steamId links and discord user mentions in link and stats commands

### DIFF
--- a/src/commands/elo/health.ts
+++ b/src/commands/elo/health.ts
@@ -59,16 +59,16 @@ class Health extends SlashCommand {
 			{ name: "Online Users", exec: async () => app.onlineUsers.length.toString() },
 			{ name: "Connected WS clients", exec: async () => app.api.clients.length.toString() },
 			{ name: "HS -> Elo Connection", exec: async () => (app.api.clients.some(u => u.isAuthedHs) ? success("Client found") : error("No client")) },
-			{ name: "Daemon -> Elo Connection", exec: async () => (app.api.clients.some(u => u.isAuthedDaemon) ? success("Client found") : error("No client")) },
-			{ name: "Seen SM Leave", exec: async () => ((await drv("seenSmLeaveMessage")) ? error("SM Leave (Steam failure)") : success("No")) },
-			{ name: "Lobby creation failed", exec: async () => ((await drv("seenLobbyCreationFailedMessage")) ? error("Lobby creation failed") : success("No")) },
-			{ name: "Last high tick rate", exec: async () => deltaTime(await drv("lastHighAverageTick")) },
-			{ name: "Exception", exec: async () => ((await drv("exceptionSeen")) ? error("Exception seen") : success("No")) },
-			{ name: "Last restart", exec: async () => deltaTime(await drv("lastRestart")) },
-			{ name: "Last user join attempt", exec: async () => deltaTime(await drv("lastUserJoinAttempt")) },
-			{ name: "Last user join success", exec: async () => deltaTime(await drv("lastUserJoinSuccess")) },
-			{ name: "Last server start", exec: async () => deltaTimeMinutes(await drv("lastCommandedServerStart")) },
-			{ name: "Last server stop", exec: async () => deltaTimeMinutes(await drv("lastServerStop")) }
+			// { name: "Daemon -> Elo Connection", exec: async () => (app.api.clients.some(u => u.isAuthedDaemon) ? success("Client found") : error("No client")) },
+			// { name: "Seen SM Leave", exec: async () => ((await drv("seenSmLeaveMessage")) ? error("SM Leave (Steam failure)") : success("No")) },
+			// { name: "Lobby creation failed", exec: async () => ((await drv("seenLobbyCreationFailedMessage")) ? error("Lobby creation failed") : success("No")) },
+			// { name: "Last high tick rate", exec: async () => deltaTime(await drv("lastHighAverageTick")) },
+			// { name: "Exception", exec: async () => ((await drv("exceptionSeen")) ? error("Exception seen") : success("No")) },
+			// { name: "Last restart", exec: async () => deltaTime(await drv("lastRestart")) },
+			// { name: "Last user join attempt", exec: async () => deltaTime(await drv("lastUserJoinAttempt")) },
+			// { name: "Last user join success", exec: async () => deltaTime(await drv("lastUserJoinSuccess")) },
+			// { name: "Last server start", exec: async () => deltaTimeMinutes(await drv("lastCommandedServerStart")) },
+			// { name: "Last server stop", exec: async () => deltaTimeMinutes(await drv("lastServerStop")) }
 		];
 
 		const embed = new Discord.EmbedBuilder();

--- a/src/commands/elo/health.ts
+++ b/src/commands/elo/health.ts
@@ -59,16 +59,16 @@ class Health extends SlashCommand {
 			{ name: "Online Users", exec: async () => app.onlineUsers.length.toString() },
 			{ name: "Connected WS clients", exec: async () => app.api.clients.length.toString() },
 			{ name: "HS -> Elo Connection", exec: async () => (app.api.clients.some(u => u.isAuthedHs) ? success("Client found") : error("No client")) },
-			// { name: "Daemon -> Elo Connection", exec: async () => (app.api.clients.some(u => u.isAuthedDaemon) ? success("Client found") : error("No client")) },
-			// { name: "Seen SM Leave", exec: async () => ((await drv("seenSmLeaveMessage")) ? error("SM Leave (Steam failure)") : success("No")) },
-			// { name: "Lobby creation failed", exec: async () => ((await drv("seenLobbyCreationFailedMessage")) ? error("Lobby creation failed") : success("No")) },
-			// { name: "Last high tick rate", exec: async () => deltaTime(await drv("lastHighAverageTick")) },
-			// { name: "Exception", exec: async () => ((await drv("exceptionSeen")) ? error("Exception seen") : success("No")) },
-			// { name: "Last restart", exec: async () => deltaTime(await drv("lastRestart")) },
-			// { name: "Last user join attempt", exec: async () => deltaTime(await drv("lastUserJoinAttempt")) },
-			// { name: "Last user join success", exec: async () => deltaTime(await drv("lastUserJoinSuccess")) },
-			// { name: "Last server start", exec: async () => deltaTimeMinutes(await drv("lastCommandedServerStart")) },
-			// { name: "Last server stop", exec: async () => deltaTimeMinutes(await drv("lastServerStop")) }
+			{ name: "Daemon -> Elo Connection", exec: async () => (app.api.clients.some(u => u.isAuthedDaemon) ? success("Client found") : error("No client")) },
+			{ name: "Seen SM Leave", exec: async () => ((await drv("seenSmLeaveMessage")) ? error("SM Leave (Steam failure)") : success("No")) },
+			{ name: "Lobby creation failed", exec: async () => ((await drv("seenLobbyCreationFailedMessage")) ? error("Lobby creation failed") : success("No")) },
+			{ name: "Last high tick rate", exec: async () => deltaTime(await drv("lastHighAverageTick")) },
+			{ name: "Exception", exec: async () => ((await drv("exceptionSeen")) ? error("Exception seen") : success("No")) },
+			{ name: "Last restart", exec: async () => deltaTime(await drv("lastRestart")) },
+			{ name: "Last user join attempt", exec: async () => deltaTime(await drv("lastUserJoinAttempt")) },
+			{ name: "Last user join success", exec: async () => deltaTime(await drv("lastUserJoinSuccess")) },
+			{ name: "Last server start", exec: async () => deltaTimeMinutes(await drv("lastCommandedServerStart")) },
+			{ name: "Last server stop", exec: async () => deltaTimeMinutes(await drv("lastServerStop")) }
 		];
 
 		const embed = new Discord.EmbedBuilder();

--- a/src/commands/elo/link.ts
+++ b/src/commands/elo/link.ts
@@ -11,11 +11,15 @@ class Link extends SlashCommand {
 	description = "Links your discord account to your steam";
 
 	async run({ interaction, framework, app }: SlashCommandEvent<Application>, @SArg() steamId: string) {
+		let id = steamId;
+
 		// Check steamid is numeric
-		const isNumeric = steamId.split("").every(c => nums.includes(c));
-		if (!isNumeric) {
-			interaction.reply(framework.error(`Please provide your steamID64 (https://steamid.io/lookup/${steamId})`));
+		const isNumeric = id.split("").every(c => nums.includes(c));
+		if (!isNumeric || !id.match(/(https):\/\/steamcommunity\.com\/profiles\/[0-9]+|(http):\/\/steamcommunity\.com\/profiles\/[0-9]+/gmi)) {
+			interaction.reply(framework.error(`Please provide your steamID64 (https://steamid.io/lookup/${id})`));
 			return;
+		} else if (id.match(/(https):\/\/steamcommunity\.com\/profiles\/[0-9]+|(http):\/\/steamcommunity\.com\/profiles\/[0-9]+/gmi)) {
+			id = id.replace(/(https):\/\/steamcommunity\.com\/profiles\/|(http):\/\/steamcommunity\.com\/profiles\//gmi, '')
 		}
 
 		// Check existing
@@ -27,7 +31,7 @@ class Link extends SlashCommand {
 		}
 
 		// Check steamid exists
-		const user = await app.users.get(steamId);
+		const user = await app.users.get(id);
 		if (!user) {
 			replyOrEdit(interaction, framework.error(`That steamID does not exist (connect to the server at least once)`));
 			return;

--- a/src/commands/elo/stats.ts
+++ b/src/commands/elo/stats.ts
@@ -11,12 +11,22 @@ import { Aircraft, User, Weapon } from "../../structures.js";
 
 async function lookupUser(users: CollectionManager<User>, query: string) {
 	// SteamID
-	const userIdUser = await users.get(query);
-	if (userIdUser) return userIdUser;
+	if (query.match(/(https):\/\/steamcommunity\.com\/profiles\/[0-9]+|(http):\/\/steamcommunity\.com\/profiles\/[0-9]+/gmi)) {
+		const userIdUser = await users.get(query.replace(/(https):\/\/steamcommunity\.com\/profiles\/|(http):\/\/steamcommunity\.com\/profiles\//gmi, ''));
+		if (userIdUser) return userIdUser;
+	} else if (query.match(/[0-9]+/gmi)) {
+		const userIdUser = await users.get(query);
+		if (userIdUser) return userIdUser;
+	}
 
 	// DiscordID
-	const discordIdUser = await users.collection.findOne({ discordId: query });
-	if (discordIdUser) return discordIdUser;
+	if (query.match(/<@[0-9]+>/gmi)) {
+		const discordIdUser = await users.collection.findOne({ discordId: query.replace(/<@|>/gmi, '') });
+		if (discordIdUser) return discordIdUser;
+	} else if (query.match(/[0-9]+/gmi)) {
+		const discordIdUser = await users.collection.findOne({ discordId: query });
+		if (discordIdUser) return discordIdUser;
+	}
 
 	console.log(`Doing regex query for ${query}`);
 	// PilotName


### PR DESCRIPTION
Previously, the link and stats commands would only accept steamIds, but with this commit they add the support for links that contain steamIds. They also add user mentions to discord so that you can directly use @ to mention somebody rather than copying a user id.

Ignore the previous commits in this pr, having 2 prs open on the same repo is strange I guess.