### PR TITLE
stats rework

### DIFF
--- a/src/commands/elo/stats.ts
+++ b/src/commands/elo/stats.ts
@@ -170,6 +170,52 @@ class Stats extends SlashCommand {
 			}
 		}
 		
+		
+		const eloGainedFrom: Record<string, number> = {};
+		const eloLostTo: Record<string, number> = {};
+		
+		kills.forEach(kill => {
+			const victimId = kill.victim.ownerId;
+			if (typeof kill.eloChange === "number") {
+				eloGainedFrom[victimId] = (eloGainedFrom[victimId] ?? 0) + kill.eloChange;
+			}
+		});
+		deaths.forEach(death => {
+			const killerId = death.killer.ownerId;
+			if (typeof death.eloChange === "number") {
+				eloLostTo[killerId] = (eloLostTo[killerId] ?? 0) - death.eloChange;
+			}
+		});
+		
+		let mostEloGainedFromId = null;
+		let mostEloGained = -Infinity;
+		for (const [id, elo] of Object.entries(eloGainedFrom)) {
+			if (elo > mostEloGained) {
+				mostEloGained = elo;
+				mostEloGainedFromId = id;
+			}
+		}
+		
+		let mostEloLostToId = null;
+		let mostEloLost = -Infinity;
+		for (const [id, elo] of Object.entries(eloLostTo)) {
+			if (elo > mostEloLost) {
+				mostEloLost = elo;
+				mostEloLostToId = id;
+			}
+		}
+		
+		let mostEloGainedFromName = "";
+		if (mostEloGainedFromId) {
+			const userObj = await app.users.get(mostEloGainedFromId);
+			mostEloGainedFromName = userObj ? userObj.pilotNames[0] : mostEloGainedFromId;
+		}
+		let mostEloLostToName = "";
+		if (mostEloLostToId) {
+			const userObj = await app.users.get(mostEloLostToId);
+			mostEloLostToName = userObj ? userObj.pilotNames[0] : mostEloLostToId;
+		}
+		
 		const aircraftMetrics = [Aircraft.FA26b, Aircraft.F45A, Aircraft.T55, Aircraft.EF24G, Aircraft.AV42c];
 		let killsWith = ``;
 		let killsAgainst = ``;

--- a/src/commands/elo/stats.ts
+++ b/src/commands/elo/stats.ts
@@ -149,20 +149,23 @@ class Stats extends SlashCommand {
 		const embed = new Discord.EmbedBuilder();
 		embed.setTitle(`Stats for ${user.pilotNames[0]}`);
 		embed.addFields([
-			{
-				name: "Metrics",
-				value: `ELO: ${Math.floor(elo)}\nRank: ${rank || "No rank"}\nTop ${((rank / playersWithRank) * 100).toFixed(0)}%\nPeak: ${Math.floor(maxElo)}`,
-				inline: true
-			},
+			{ name: "Metrics", value: `ELO: ${Math.floor(elo)}\nRank: ${rank || "No rank"}\nTop ${((rank / playersWithRank) * 100).toFixed(0)}%\nPeak: ${Math.floor(maxElo)}`, inline: true},
 			{ name: "KDR", value: `K: ${kills.length} \nD: ${deaths.length} \nR: ${(kills.length / deaths.length).toFixed(2)}`, inline: true },
-			// { name: "Online time", value: `${(timeOnServer / 1000 / 60 / 60).toFixed(2)} hours`, inline: true },
-			{ name: "Last Online", value: lastOnlineTimeStamp, inline: true },
+			{ name: "Online Stats", value: `Last Online: ${lastOnlineTimeStamp}\nOnline Time: ${(timeOnServer / 1000 / 60 / 60).toFixed(2)} hours`, inline: true },
+			//end row 1
 			{ name: "Kills with", value: killsWith, inline: true },
 			{ name: "Kills against", value: killsAgainst, inline: true },
 			{ name: "Deaths against", value: deathsAgainst, inline: true },
+			//end row 2
 			{ name: "Weapons", value: weaponKillsStr || "<No Data>", inline: true },
-			{ name: "Died to", value: weaponDeathsStr || "<No Data>", inline: true }
-			// { name: "Kills per hour", value: `${(user.kills / (timeOnServer / 1000 / 60 / 60)).toFixed(2)}`, inline: true },
+			{ name: "Died to", value: weaponDeathsStr || "<No Data>", inline: true },
+			{ name: "Kills per hour", value: `${(user.kills / (timeOnServer / 1000 / 60 / 60)).toFixed(2)}`, inline: true },
+			//end row 3
+			{// name: "Interesting Stats", value: `Longest Killstreak ${}\nLongest Deathstreak ${}`, inline: true },
+			{// name: "Nemesis Stats", value `Most Elo Lost To ${}\nMost Elo Gained From ${}\Most Kills VS ${}, Most Deaths VS ${}`,
+			//end row 4
+			
+		
 		]);
 
 		let achievementLogText = "";


### PR DESCRIPTION
- Added Discord profile picture embed check for linked accounts
- Added Colour banner
- Removed Last Online
- Added Online Stats - Merging Last Online with previously unused Online Time line
- Added 4th Line 
>"Interesting Stats": Longest Killstreak, Longest Deathstreak
>"VS Stats": Most Elo Gained From, Most Elo Lost To, Most Killed Player, Most Deaths to Player

- Added supporting logic for Line 4

im sorry if it explodes

